### PR TITLE
Feature/view system object defs

### DIFF
--- a/Exapmles/OCAPI_Settings.json
+++ b/Exapmles/OCAPI_Settings.json
@@ -1,0 +1,21 @@
+{
+  "_v": "18.8",
+    "clients":
+  [
+    {
+      "allowed_origins": [],
+      "client_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "resources":
+        [
+          {
+            "resource_id": "/system_object_definitions",
+            "methods": ["get"],
+            "read_attributes": "(**)",
+            "write_attributes": "(**)",
+            "cache_time": 900,
+            "version_range": { "from": "18.8" }
+          }
+        ]
+    }
+  ]
+}

--- a/src/components/MetadataNode.ts
+++ b/src/components/MetadataNode.ts
@@ -4,22 +4,57 @@
  * on a tree view for display of SFCC metadata objects. This is a generic class used
  */
 
-import { Command, TreeItemCollapsibleState, TreeItem } from "vscode";
+import { Command, TreeItemCollapsibleState, TreeItem } from 'vscode';
+import ObjectAttributeDefinition from '../documents/ObjectAttributeDefinition';
+import ObjectAttributeGroup from '../documents/ObjectAttributeGroup';
+import ObjectTypeDefinition from '../documents/ObjectTypeDefinition';
+import { ObjectTypeDefinitions } from '../documents/ObjectTypeDefinitions';
 
 /**
  * @class MetadataNode
+ * @extends TreeItem
  * @classdesc A generic class representing a metadata entity returned from a
- * reqeust to OCAPI.
+ * reqeust to OCAPI. This can be an an object type, attribute group, attribute,
+ * property, or value.
  */
 export class MetadataNode extends TreeItem {
+  _expandable: boolean;
+  _nodeType: string;
+  _objectTypeDefinition: ObjectTypeDefinition;
+
+  /**
+   * The constructor function that calls the super class constructor, and then
+   * initializes the custom logic for the MetaNode class.
+   *
+   * @param {string} name - The name of the node to be used as a label.
+   * @param {TreeItemCollapsibleState} collapsibleState - The collapsible state
+   *    constant: 'Collapsed', 'Expanded', & 'None'.
+   * @param {ObjectTypeDefinition | ObjectAttributeDefinition | ObjectAttributeGroup | string} value - The object type
+   *    definition instance, or an empty instance if this is only a parent
+   *    container.
+   * @constructor
+   */
   constructor(
     public readonly name: string,
-    public readonly collapsibleState: TreeItemCollapsibleState
+    public readonly collapsibleState: TreeItemCollapsibleState,
+    args: INodeData
   ) {
     super(name, collapsibleState);
+
+    // Create the ObjectTypeDefinition member instance. Create an empty one if
+    // this is a parent node.
+    if (typeof args.objectTypeDefinition !== 'undefined') {
+      this._objectTypeDefinition = args.objectTypeDefinition;
+    }
+
+
   }
 
   get tooltip(): string {
     return this.name;
+  }
+
+  get expandable(): boolean {
+    return this._expandable;
   }
 }

--- a/src/components/MetadataViewProvider.ts
+++ b/src/components/MetadataViewProvider.ts
@@ -97,8 +97,12 @@ export class MetadataViewProvider
             // Create a MetaDataNode instance which implements the TreeItem
             // interface and holds the data of the document type that it
             // represents.
-            const node = new MetadataNode(name, TreeItemCollapsibleState.None,
-              new ObjectTypeDefinition(sysObj));
+            const node = new MetadataNode(
+              name,
+              TreeItemCollapsibleState.None,
+              { objectTypeDefinition: new ObjectTypeDefinition(sysObj) }
+            );
+
             return node;
           });
         }
@@ -110,8 +114,9 @@ export class MetadataViewProvider
         return Promise.reject(e);
       }
     } else {
-      if (element.attribute_group_count > 0) {
-
+      // Only expandable elements have children.
+      if (element.expandable) {
+        if (element.nodeType === )
       }
     }
   }

--- a/src/documents/ObjectAttributeDefinition.ts
+++ b/src/documents/ObjectAttributeDefinition.ts
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * ObjectAttributeDefinition.ts
+ *
+ * Exports the ObjectAttributeDefinition class which is a model for the OCAPI
+ * document representing an attribute definition of a system or custom object.
+ */
+
+
+/**
+ * @class
+ * Used for handling the OCAPI document for an ObjectAttributeDefinition.
+ *
+ * @param {Object} args - The raw JSON object document returned from a call to
+ *      SFCC OCAPI.
+ */
+export default class ObjectAttributeDefinition {
+    constructor(args) {
+        /** @todo */
+    }
+}

--- a/src/documents/ObjectAttributeGroup.ts
+++ b/src/documents/ObjectAttributeGroup.ts
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * ObjectAttributeGroup.ts
+ *
+ * Exports the ObjectAttributeGroup class which is a model for the OCAPI
+ * document representing an attribute group of a system or custom object.
+ */
+
+
+/**
+ * @class
+ * Used for handling the OCAPI document for an ObjectAttributeGroup.
+ *
+ * @param {Object} args - The raw JSON object document returned from a call to
+ *      SFCC OCAPI.
+ */
+export default class ObjectAttributeGroup {
+    constructor(args) {
+        /** @todo */
+    }
+}

--- a/src/documents/ObjectTypeDefinitions.ts
+++ b/src/documents/ObjectTypeDefinitions.ts
@@ -4,15 +4,15 @@
  * object_type_definitions document type.
  */
 
-import ObjectTypeDefinition from "./ObjectTypeDefinition";
+import ObjectTypeDefinition from './ObjectTypeDefinition';
 
 export class ObjectTypeDefinitions {
   public count: number = 0;
   public data: ObjectTypeDefinition[] = [];
   public expand: string[] = [];
-  public next: string = "";
-  public previous: string = "";
-  public select: string = "";
+  public next: string = '';
+  public previous: string = '';
+  public select: string = '';
   public start: number = 0;
   public total: number = 0;
 

--- a/src/interfaces/INodeData.ts
+++ b/src/interfaces/INodeData.ts
@@ -1,0 +1,18 @@
+import ObjectTypeDefinition from "../documents/ObjectTypeDefinition";
+import ObjectAttributeDefinition from "../documents/ObjectAttributeDefinition";
+
+'use strict';
+
+/**
+ * INodeData.ts
+ *
+ * Describes an interface for a MetadataNode class instances associated data
+ * object that represents a system or custom object, and object attribute group,
+ * or an object attribute definition.
+ */
+
+export default interface INodeData {
+    objectAttributeDefinition?: ObjectAttributeDefinition
+    objectTypeDefinition?: ObjectTypeDefinition,
+    type: string
+}

--- a/src/interfaces/INodeData.ts
+++ b/src/interfaces/INodeData.ts
@@ -1,5 +1,7 @@
-import ObjectTypeDefinition from "../documents/ObjectTypeDefinition";
-import ObjectAttributeDefinition from "../documents/ObjectAttributeDefinition";
+
+import ObjectTypeDefinition from '../documents/ObjectTypeDefinition';
+import ObjectAttributeGroup from '../documents/ObjectAttributeGroup';
+import ObjectAttributeDefinition from '../documents/ObjectAttributeDefinition';
 
 'use strict';
 
@@ -12,7 +14,8 @@ import ObjectAttributeDefinition from "../documents/ObjectAttributeDefinition";
  */
 
 export default interface INodeData {
-    objectAttributeDefinition?: ObjectAttributeDefinition
-    objectTypeDefinition?: ObjectTypeDefinition,
-    type: string
+    objectAttributeDefinition?: ObjectAttributeDefinition,
+    obtectAttributeGroup?: ObjectAttributeGroup,
+    objectTypeDefinition?: ObjectTypeDefinition
+    nodeValue?: string|number
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "exclude": [
         "node_modules",
         ".vscode",
-        "test"
+        "test",
+        "Examples"
     ]
 }


### PR DESCRIPTION
## Summary
Basic display of system & custom object definitions from a SFCC instance in a tree view.


## Details
- Added tree node data members and member functions to the MetaData class.
- Setup the tree-nodes to allow for generic typing and type inference -- looking ahead to retrieval of the ObjectAttributeDefinition document and ObjectAttributeGroup document types.
- Added a new folder for code examples and/or setup file examples.
- Added an example OCAPI config for BM to expose the needed call (only 1 so far but will update as the extension needs more access) for the default test client id (30 lower case 'a' characters).

