### PR TITLE
Feature/view system object defs

### DIFF
--- a/src/components/MetadataNode.ts
+++ b/src/components/MetadataNode.ts
@@ -24,7 +24,7 @@ export class MetadataNode extends TreeItem {
   objectAttributeDefinition: ObjectAttributeDefinition;
   objectAttributeGroup: ObjectAttributeGroup;
   objectTypeDefinition: ObjectTypeDefinition;
-  value: string|number;
+  value: string | number;
 
   /**
    * @static
@@ -56,8 +56,12 @@ export class MetadataNode extends TreeItem {
     public readonly collapsibleState: TreeItemCollapsibleState,
     nodeData: INodeData
   ) {
+    // Call the TreeNode constructor.
     super(name, collapsibleState);
-    const expandableTypes = ['group', 'definition', 'attribute', 'value'];
+
+    // The types of tree nodes that have child nodes.
+    const expandableTypes = Object.keys(MetadataNode.nodeTypes)
+      .filter(nodeType => nodeType !== 'value');
 
     // Loop through the nodeData Object properties to get the correct type.
     // There will only be one property, since the node can only be one of the
@@ -77,7 +81,6 @@ export class MetadataNode extends TreeItem {
 
   /* Member Mutators & Accessors
      ======================================================================== */
-
   /** @member {boolean} expandable - Boolean for if the node is expandable. */
   get expandable(): boolean { return this._expandable; }
   set expandable(value: boolean) { this._expandable = value; }

--- a/src/components/MetadataViewProvider.ts
+++ b/src/components/MetadataViewProvider.ts
@@ -116,7 +116,13 @@ export class MetadataViewProvider
     } else {
       // Only expandable elements have children.
       if (element.expandable) {
-        if (element.nodeType === )
+        if (element.nodeType === 'objectTypeDefinition') {
+          // Get the System/Custom Object attributes.
+
+
+        } else if (element.nodeType === 'objectAttributeDefinition') {
+          /** @todo - Get children for object attribute definiton */
+        }
       }
     }
   }

--- a/src/components/MetadataViewProvider.ts
+++ b/src/components/MetadataViewProvider.ts
@@ -74,17 +74,17 @@ export class MetadataViewProvider
         // If the API call returns data create a tree.
         if (_callResult.data && Array.isArray(_callResult.data)) {
           // Sort the SystemObjects & the CustomObjects
-          const custObjectArray = [];
-          const sysObjectArray = [];
-          _callResult.data.forEach(resultObject => {
-            if (resultObject.object_type === 'CustomObject' &&
-              typeof resultObject.display_name !== 'undefined'
-            ) {
-              custObjectArray.push(resultObject);
-            } else {
-              sysObjectArray.push(resultObject);
-            }
-          });
+          // const custObjectArray = [];
+          // const sysObjectArray = [];
+          // _callResult.data.forEach(resultObject => {
+          //   if (resultObject.object_type === 'CustomObject' &&
+          //     typeof resultObject.display_name !== 'undefined'
+          //   ) {
+          //     custObjectArray.push(resultObject);
+          //   } else {
+          //     sysObjectArray.push(resultObject);
+          //   }
+          // });
 
 
           return _callResult.data.map(sysObj => {
@@ -99,7 +99,7 @@ export class MetadataViewProvider
             // represents.
             const node = new MetadataNode(
               name,
-              TreeItemCollapsibleState.None,
+              TreeItemCollapsibleState.Collapsed,
               { objectTypeDefinition: new ObjectTypeDefinition(sysObj) }
             );
 


### PR DESCRIPTION
This feature is now complete. The system Objects are displayed in a list fashion as seen in the screen capture:
![image](https://user-images.githubusercontent.com/16811151/48239561-50d05000-e39d-11e8-80cc-f9d2dc9e4995.png)
