### PR TITLE
[ feature / View SystemObject Attribute Definitions ] Finish display of system object definition attributes.

### DIFF
--- a/src/apiConfig.ts
+++ b/src/apiConfig.ts
@@ -16,8 +16,7 @@ export const apiConfig = {
     systemObjectDefinitions: {
       api: 'data',
       availableCalls: {
-        // Gets the list of system object definitions, filtered by any included
-        // query parameters.
+        // Gets a single system object definition.
         get: {
           authorization: 'BM_USER',
           headers: {
@@ -51,7 +50,29 @@ export const apiConfig = {
           ],
           path: 'system_object_definitions',
         },
-        //
+
+        // Get a list of the system object attributes for the specified system
+        // object type.
+        attributes: {
+          authorization: 'BM_USER',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          method: 'GET',
+          params: [
+            {
+              id: 'select',
+              type: 'string',
+              use: 'QUERY_PARAMETER'
+            },{
+              id: 'objectType',
+              type: 'string',
+              use: 'PATH_PARAMETER'
+            }
+
+          ],
+          path: 'system_object_definitions/{objectType}/attribute_definitions'
+        },
       }
     }
   },

--- a/src/service/OCAPIService.ts
+++ b/src/service/OCAPIService.ts
@@ -37,12 +37,12 @@ export class OCAPIService {
    * Returns an object literal that conforms to the ICallSetup interface so that
    * it can be passed directly to the makeCall() method of this class.
    * @public
-   * @param callName - The name of the SFCC OCAPI call to make. The name is
+   * @param {string} resourceName - The name of the OCAPI Data API resource to query.
+   * @param {string} callName - The name of the SFCC OCAPI call to make. The name is
    *    in the format that is used in the URI to identify which asset we are
    *    requesting form the server.
-   * @param callData - An object of key/value pairs to be extracted into the
+   * @param {Object} [callData] - An object of key/value pairs to be extracted into the
    *    URL parameters, headers, and body of the OCAPI request.
-   * @param resourceName - The name of the OCAPI Data API resource to query.
    * @returns An object conforming to the ICallSetup interface with the data
    *    for making the call to the API endpoint, or an appropriate error
    *    message.
@@ -147,7 +147,8 @@ export class OCAPIService {
             param.use === 'PATH_PARAMETER' &&
             setupResult.endpoint.indexOf(replaceMe) > -1
           ) {
-            setupResult.endpoint.replace(replaceMe, callData[param.id]);
+            setupResult.endpoint = setupResult.endpoint.replace(
+                replaceMe, callData[param.id]);
           } else if (param.use === 'QUERY_PARAMETER') {
             // Check if this is the first query string parameter, or an
             // additional parameter being added to the list.
@@ -303,7 +304,9 @@ export class OCAPIService {
       if (resp.ok) {
         return resp.json();
       } else {
-        console.error(resp);
+        const errMsg = resp.statusText + ' :: Code ' + resp.status;
+        console.error(errMsg);
+        return { error: true, errorMessage: errMsg };
       }
     });
   }


### PR DESCRIPTION
## Summary
Added a call to get system object attribute definitions and display them as children of the system object definitions within the tree view:
![image](https://user-images.githubusercontent.com/16811151/48295200-ce589680-e457-11e8-8c77-4ec3630e6899.png)


## Commits
- Added a definition for the call to get system object attributes to the api config.
- Added logic to call the service to get the attribute definitions if the element passed into the TreeDataProvider instance is a MetaDataNode whith type===systemObjectAttribute.
- Made updates to the service for better logging and error handling.
==== TODO: Remove some console statements once finished with development =====