### PR TITLE
Feature/view system object attribute groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This extension provides Sales Force Comerce Cloud (SFCC) developers with an alte
    * Each attribute is in turn expandable to view information about the attribute, including attribute type, id, display name, etc.
 * #### View Custom Object Definitions.
    * Custom objects are currently displayed within the list of System Objects with the qualifyer '(Custom Object)' printed after the CustomObjectDefinition's Id (see screen capture below).
-* #### View System Objec of a system object.
+* #### View Attribute Definitions of System Object
+* #### View Attribute Groups of a System Object
 * #### Add Attribute Definition to System Object
    * Each system object attribute has a context menu (right click or CMD+click) with a command to create a new attribute definition.
    * Several inputs are shown to gather information about the new attribute definition:
@@ -53,9 +54,11 @@ _Because this extension is still in the initial development, additional issues w
 
 ## Release Notes
 
+Release of a Beta version of this extension will be in the near future.
+
 ### Updates since last release
 
-
+- Viewing of system object attribute groups is now supported.
 - Context menu action has been added to the system objects for adding a new system object attribute.
   - The attribute details are collected through a wizard that gets the value of each field, and then makes a single call to the Open Commerce API to create the new system object attribute definition.
 - Display of the system & custom objects has been added.

--- a/package.json
+++ b/package.json
@@ -40,13 +40,18 @@
         "description": "Get system object definitions from sandbox."
       },
       {
-        "command": "extension.sfccexplorer.systemobjectattribute.add",
+        "command": "extension.sfccexplorer.systemobject.addattribute",
         "title": "Add a New System Object Attribute",
         "description": "Add a new attribute to a SFCC system object on a connected sandbox.",
         "icon": {
           "dark": "resources/dark/add.svg",
           "light": "resources/light/add.svg"
         }
+      },
+      {
+        "command": "extension.sfccexplorer.systemobjectattribute.setdefault",
+        "title": "Set Default Value of System Object Attribute",
+        "description": "Sets the default value of a custom attribute of the SitePreferences system object."
       },
       {
         "command": "extension.sfccexplorer.refresh",
@@ -67,8 +72,12 @@
       ],
       "view/item/context": [
         {
-          "command": "extension.sfccexplorer.systemobjectattribute.add",
+          "command": "extension.sfccexplorer.systemobject.addattribute",
           "when": "view == systemObjectDefinitionsView && viewItem == definition"
+        },
+        {
+          "command": "extension.sfccexplorer.systemobjectattribute.setdefault",
+          "when": "view == systemObjectDefinitionsView && viewItem =~ attribute"
         }
       ]
     },

--- a/src/apiConfig.ts
+++ b/src/apiConfig.ts
@@ -101,6 +101,27 @@ export const apiConfig = {
           ],
           path: 'system_object_definitions/{objectType}/attribute_definitions/{id}'
         },
+
+        // Get the attribute groups
+        getAttributeGroups: {
+          authorization: 'BM_USER',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          method: 'GET',
+          params: [
+            {
+              id: 'select',
+              type: 'string',
+              use: 'QUERY_PARAMETER'
+            },{
+              id: 'objectType',
+              type: 'string',
+              use: 'PATH_PARAMETER'
+            }
+          ],
+          path: 'system_object_definitions/{objectType}/attribute_groups'
+        }
       }
     }
   },

--- a/src/components/MetadataNode.ts
+++ b/src/components/MetadataNode.ts
@@ -27,6 +27,7 @@ export class MetadataNode extends TreeItem {
   public objectAttributeGroup: ObjectAttributeGroup;
   public objectAttributeValueDefinition: ObjectAttributeValueDefinition;
   public objectTypeDefinition: ObjectTypeDefinition;
+  public parentId: string;
   public value: string | number;
 
   /**
@@ -36,6 +37,7 @@ export class MetadataNode extends TreeItem {
    *    document types.
    */
   public static nodeTypes = {
+    parentContainer: 'parentContainer',
     baseNodeName: 'baseNodeName',
     definition: 'objectTypeDefinition',
     attribute: 'objectAttributeDefinition',
@@ -63,6 +65,7 @@ export class MetadataNode extends TreeItem {
   ) {
     // Call the TreeNode constructor.
     super(name, collapsibleState);
+    const instance = this;
 
     // The types of tree nodes that have child nodes.
     const expandableTypes = Object.keys(MetadataNode.nodeTypes)
@@ -71,18 +74,21 @@ export class MetadataNode extends TreeItem {
     // Loop through the nodeData Object properties to get the correct type.
     // There will only be one property, since the node can only be one of the
     // specified types.
-    Object.keys(nodeData).forEach(_dataType => {
-      this[_dataType] = nodeData[_dataType];
-      const nodeTypeIndex = expandableTypes.findIndex(type => {
-        return MetadataNode.nodeTypes[type] === _dataType;
-      });
-      this._nodeType = expandableTypes[nodeTypeIndex];
-      this.contextValue = expandableTypes[nodeTypeIndex];
-    });
+    Object.keys(nodeData)
+      .filter(attrName => attrName !== 'parentId')
+      .forEach(_dataType => {
+        instance[_dataType] = nodeData[_dataType];
+        const nodeTypeIndex = expandableTypes.findIndex(type => {
+          return MetadataNode.nodeTypes[type] === _dataType;
+        });
+        instance._nodeType = expandableTypes[nodeTypeIndex];
+        instance.contextValue = expandableTypes[nodeTypeIndex];
+      }
+    );
 
     // Set the instance member properties for the child Class.
     this._expandable = expandableTypes.indexOf(this._nodeType) > -1;
-    this[this.nodeType] = nodeData[this.nodeType];
+    this.parentId = nodeData.parentId;
   }
 
   /* Member Mutators & Accessors

--- a/src/components/MetadataViewProvider.ts
+++ b/src/components/MetadataViewProvider.ts
@@ -9,9 +9,9 @@ import { MetadataNode } from './MetadataNode';
 import {
   Event,
   EventEmitter,
-  Range,
   TreeDataProvider,
   TreeItemCollapsibleState,
+  window,
   WorkspaceConfiguration,
   workspace
 } from 'vscode';
@@ -19,6 +19,7 @@ import { OCAPIService } from '../service/OCAPIService';
 import { ICallSetup } from '../service/ICallSetup';
 import ObjectTypeDefinition from '../documents/ObjectTypeDefinition';
 import ObjectAttributeDefinition from '../documents/ObjectAttributeDefinition';
+import ObjectAttributeGroup from '../documents/ObjectAttributeGroup';
 import ObjectAttributeValueDefinition from '../documents/ObjectAttributeValueDefinition';
 
 /**
@@ -33,6 +34,7 @@ export class MetadataViewProvider
   readonly onDidChangeTreeData?: Event<MetadataNode | undefined>;
   public providerType: string = '';
   private eventEmitter: EventEmitter<MetadataNode | undefined> = null;
+  private service: OCAPIService = new OCAPIService();
 
   /**
    *
@@ -75,214 +77,28 @@ export class MetadataViewProvider
    * @return {Promise<MetadataNode[]>}
    */
   async getChildren(element?: MetadataNode): Promise<MetadataNode[]> {
-    const service: OCAPIService = new OCAPIService();
-    let _callSetup: ICallSetup = null;
-    let _callResult: any;
-
     try {
-      /* No Element -- Root
-         ==================================================================== */
       if (!element) {
-        const metaNodes: MetadataNode[] = [];
-
-        // Get the workspace configuration object for all configuration settings
-        // related to this extension.
-        const workspaceConfig: WorkspaceConfiguration = workspace.getConfiguration(
-          'extension.sfccmetadata'
-        );
-
-        // Get the VSCode settings for display of each base tree node.
-        const showSystemObjects: boolean = Boolean(
-          workspaceConfig.get('explorer.systemobjects')
-        );
-
-        // If the user config is enabled, then show the option.
-        if (showSystemObjects) {
-          metaNodes.push(
-            new MetadataNode(
-              'System Object Definitions',
-              TreeItemCollapsibleState.Collapsed,
-              { baseNodeName: 'systemObjectDefinitions' }
-            )
-          );
-        }
-
-        return Promise.resolve(metaNodes);
+        // Get the base nodes of the tree.
+        return this.getRootChildren(element);
       } else {
-        // Only expandable elements types have children.
+        // Get children of expandable node types
         if (element.expandable) {
           if (element.nodeType === 'baseNodeName') {
-            /* Base Node -- Metdata Type
-             * ============================================================== */
-            // Async call to get the appropriate OCAPI type.
-            _callSetup = await service.getCallSetup(
-              element.baseNodeName,
-              'getAll',
-              {
-                count: 200,
-                select: '(**)'
-              }
-            );
-
-            try {
-              _callResult = await service.makeCall(_callSetup);
-            } catch (e) {
-              console.log(e);
-              throw new Error(e.toString());
-            }
-
-            // If the API call returns data create a tree.
-            if (_callResult.data && Array.isArray(_callResult.data)) {
-              // Add the display name to the custom objects so that they can be
-              // easily identified as custom.
-              return _callResult.data.map(sysObj => {
-                let name =
-                  sysObj.object_type === 'CustomObject' &&
-                  typeof sysObj.display_name !== 'undefined'
-                    ? sysObj.display_name.default + ' (CustomObject)'
-                    : sysObj.object_type;
-
-                // Create a MetaDataNode instance which implements the TreeItem
-                // interface and holds the data of the document type that it
-                // represents.
-                return new MetadataNode(
-                  name,
-                  TreeItemCollapsibleState.Collapsed,
-                  {
-                    objectTypeDefinition: new ObjectTypeDefinition(sysObj)
-                  }
-                );
-              });
-            }
+            return this.getBaseNodeChildren(element);
           } else if (element.nodeType === 'objectTypeDefinition') {
-            /* Object Type Definiton
-             * ============================================================== */
-            // Get the System/Custom Object attributes.
-            _callSetup = await service.getCallSetup(
-              'systemObjectDefinitions',
-              'getAttributes',
-              {
-                select: '(**)',
-                objectType: element.objectTypeDefinition.objectType
-              }
-            );
-
-            // Make the call to the OCAPI Service.
-            try {
-              _callResult = await service.makeCall(_callSetup);
-            } catch (e) {
-              console.error(e);
-              throw new Error(e.toString());
-            }
-
-            console.log(_callResult);
-
-            // If the API call returns data create the first level of a tree.
-            if (!_callResult.error &&
-                typeof _callResult.data !== 'undefined' &&
-                Array.isArray(_callResult.data)
-            ) {
-              return _callResult.data.map(resultObj => {
-                return new MetadataNode(
-                  resultObj.id,
-                  TreeItemCollapsibleState.Collapsed,
-                  {
-                    objectAttributeDefinition: new ObjectAttributeDefinition(
-                      resultObj
-                    )
-                  }
-                );
-              });
-            }
-
-            // If there is an error display a single node indicating that there
-            // was a failure to load the object definitions.
-            return [
-              new MetadataNode(
-                'Unable to load...',
-                TreeItemCollapsibleState.None,
-                {}
-              )
-            ];
+            return this.getSystemObjectChildren(element);
+          } else if (element.nodeType === 'parentContainer') {
+            return this.getAttributeOrGroupContainerChildren(element);
           } else if (element.nodeType === 'objectAttributeDefinition') {
-            /* Object Attribute Definiton
-             * ============================================================== */
-            const objAttrDef: ObjectAttributeDefinition =
-              element.objectAttributeDefinition;
-
-            // Loop through the member properties and handle each possible type
-            // for display as a node on the tree.
-            return Object.keys(objAttrDef).map(key => {
-              // == Primitive Types
-              if (
-                typeof objAttrDef[key] === 'string' ||
-                typeof objAttrDef[key] === 'number' ||
-                typeof objAttrDef[key] === 'boolean'
-              ) {
-                return new MetadataNode(
-                  key + ' : ' + objAttrDef[key],
-                  TreeItemCollapsibleState.None,
-                  {}
-                );
-              } else if (
-                // == Localized Strings
-                typeof objAttrDef[key] === 'object' &&
-                objAttrDef[key] !== null &&
-                typeof objAttrDef[key].default === 'string'
-              ) {
-                return new MetadataNode(
-                  key + ' : ' + objAttrDef[key].default,
-                  TreeItemCollapsibleState.None,
-                  {}
-                );
-              } else if (
-                objAttrDef[key] instanceof ObjectAttributeValueDefinition
-              ) {
-                // == ObjectAttributeValueDefinition
-                if (typeof objAttrDef[key].id !== 'undefined') {
-                  return new MetadataNode(
-                    key + ': ' + objAttrDef[key].id,
-                    TreeItemCollapsibleState.Collapsed,
-                    { objectAttributeValueDefinition: objAttrDef[key] }
-                  );
-                }
-                return new MetadataNode(
-                  key + ': (undefined)',
-                  TreeItemCollapsibleState.None,
-                  { objectAttributeValueDefinition: objAttrDef[key] }
-                );
-              }
-            });
+            return this.getAttributeDefinitionChildren(element);
+          } else if (element.nodeType === 'objectAttributeGroup') {
+            return this.getAttributeGroupChildren(element);
           } else if (element.nodeType === 'objectAttributeValueDefinition') {
-            /* OjbectAttributeValueDefinition
-             * ============================================================== */
-            return Object.keys(element.objectAttributeValueDefinition).map(
-              key => {
-                const value = element.objectAttributeValueDefinition[key];
-
-                if (
-                  typeof value === 'string' ||
-                  typeof value === 'number' ||
-                  typeof value === 'boolean'
-                ) {
-                  // == Primitive Types
-                  return new MetadataNode(
-                    key + ': ' + value,
-                    TreeItemCollapsibleState.None,
-                    {}
-                  );
-                } else {
-                  // == Localized String
-                  return new MetadataNode(
-                    key + ': ' + value.default,
-                    TreeItemCollapsibleState.None,
-                    {}
-                  );
-                }
-              }
-            );
+            return this.getAttributeValueDefinitionChildren(element);
           }
         } else {
+          // Return an empty array for types that are not expandable.
           return [];
         }
       }
@@ -293,5 +109,353 @@ export class MetadataViewProvider
       console.error(e);
       return Promise.reject(e);
     }
+  }
+
+  /**
+   * Gets the children elements of AttributeValueDefinition type nodes.
+   * @param {MetadataNode} element - The MetadataNode instance.
+   * @return {Promise<MetadataNode[]>}
+   */
+  private async getAttributeOrGroupContainerChildren(
+    element: MetadataNode
+  ): Promise<MetadataNode[]> {
+    const path = element.parentId.split('.');
+    const objectType = path.pop();
+    const isAttribute = element.name !== 'Attribute Groups';
+    let _callSetup: ICallSetup = null;
+    let _callResult: any;
+
+    // If this is the node for attribute definitions.
+    if (isAttribute) {
+      // Get the System/Custom Object attributes.// Make the call to the OCAPI Service.
+      try {
+        _callSetup = await this.service.getCallSetup(
+          'systemObjectDefinitions',
+          'getAttributes',
+          {
+            select: '(**)',
+            objectType: objectType
+          }
+        );
+
+        _callResult = await this.service.makeCall(_callSetup);
+      } catch (e) {
+        console.error(e);
+        throw new Error(e.toString());
+      }
+
+      // If the API call returns data create the first level of a tree.
+      if (
+        !_callResult.error &&
+        typeof _callResult.data !== 'undefined' &&
+        Array.isArray(_callResult.data)
+      ) {
+        return _callResult.data.map(resultObj => {
+          return new MetadataNode(
+            resultObj.id,
+            TreeItemCollapsibleState.Collapsed,
+            {
+              parentId: element.parentId + '.' + objectType,
+              objectAttributeDefinition: new ObjectAttributeDefinition(
+                resultObj
+              )
+            }
+          );
+        });
+      }
+
+      // If there is an error display a single node indicating that there
+      // was a failure to load the object definitions.
+      return [
+        new MetadataNode('Unable to load...', TreeItemCollapsibleState.None, {
+          parentId: 'root.systemObjectDefinitions.' + objectType
+        })
+      ];
+    } else {
+      // Make the call to the OCAPI Service to get the attribute groups.
+      // Tree branch for attribute groups.
+      _callSetup = await this.service.getCallSetup(
+        'systemObjectDefinitions',
+        'getAttributeGroups',
+        {
+          select: '(**)',
+          objectType: objectType
+        }
+      );
+
+      _callResult = await this.service.makeCall(_callSetup);
+
+      // If the API call returns data create the first level of a tree.
+      if (
+        !_callResult.error &&
+        typeof _callResult.data !== 'undefined' &&
+        Array.isArray(_callResult.data)
+      ) {
+        return _callResult.data.map(resultObj => {
+          return new MetadataNode(
+            resultObj.id,
+            TreeItemCollapsibleState.Collapsed,
+            {
+              parentId: element.parentId + '.' + objectType,
+              objectAttributeGroup: new ObjectAttributeGroup(resultObj)
+            }
+          );
+        });
+      } else if (
+        !_callResult.error &&
+        typeof _callResult.count !== 'undefined' &&
+        _callResult.count === 0
+      ) {
+        // If there are no attribute groups defined then create a single node
+        // with a message for the user.
+        return [
+          new MetadataNode(
+            'No attribute groups defined',
+            TreeItemCollapsibleState.None,
+            {
+              parentId: element.parentId + '.' + objectType
+            }
+          )
+        ];
+      }
+
+      // If there is an error display a single node indicating that there
+      // was a failure to load the object definitions.
+      return [
+        new MetadataNode('Unable to load...', TreeItemCollapsibleState.None, {
+          parentId: element.parentId + '.' + objectType
+        })
+      ];
+    }
+  }
+
+  /**
+   * Gets the children elements of base tree nodes.
+   * @param {MetadataNode} element - The MetadataNode instance.
+   * @return {Promise<MetadataNode[]>}
+   */
+  private async getBaseNodeChildren(
+    element: MetadataNode
+  ): Promise<MetadataNode[]> {
+    const _callSetup: ICallSetup = await this.service.getCallSetup(
+      element.baseNodeName,
+      'getAll',
+      {
+        count: 200,
+        select: '(**)'
+      }
+    );
+
+    const _callResult = await this.service.makeCall(_callSetup);
+
+    // If the API call returns data create a tree.
+    if (_callResult.data && Array.isArray(_callResult.data)) {
+      // Add the display name to the custom objects so that they can be
+      // easily identified as custom.
+      return _callResult.data.map(sysObj => {
+        let name =
+          sysObj.object_type === 'CustomObject' &&
+          typeof sysObj.display_name !== 'undefined'
+            ? sysObj.display_name.default + ' (CustomObject)'
+            : sysObj.object_type;
+
+        // Create a MetaDataNode instance which implements the TreeItem
+        // interface and holds the data of the document type that it
+        // represents.
+        return new MetadataNode(name, TreeItemCollapsibleState.Collapsed, {
+          parentId: 'root.systemObjectDefinitions',
+          objectTypeDefinition: new ObjectTypeDefinition(sysObj)
+        });
+      });
+    }
+  }
+
+  /**
+   * Gets the children the root element.
+   * @param {MetadataNode} element - The MetadataNode instance.
+   * @return {Promise<MetadataNode[]>}
+   */
+  private async getRootChildren(
+    element: MetadataNode
+  ): Promise<MetadataNode[]> {
+    const metaNodes: MetadataNode[] = [];
+
+    // Get the workspace configuration object for all configuration settings
+    // related to this extension.
+    const workspaceConfig: WorkspaceConfiguration = workspace.getConfiguration(
+      'extension.sfccmetadata'
+    );
+
+    // Get the VSCode settings for display of each base tree node.
+    const showSystemObjects: boolean = Boolean(
+      workspaceConfig.get('explorer.systemobjects')
+    );
+
+    // If the user config is enabled, then show the option.
+    if (showSystemObjects) {
+      metaNodes.push(
+        new MetadataNode(
+          'System Object Definitions',
+          TreeItemCollapsibleState.Collapsed,
+          {
+            parentId: 'root',
+            baseNodeName: 'systemObjectDefinitions'
+          }
+        )
+      );
+    }
+
+    return Promise.resolve(metaNodes);
+  }
+
+  /**
+   * Gets the children elements of AttributeValueDefinition type nodes.
+   * @param {MetadataNode} element - The MetadataNode instance.
+   * @return {Promise<MetadataNode[]>}
+   */
+  private async getSystemObjectChildren(
+    element: MetadataNode
+  ): Promise<MetadataNode[]> {
+    const displayTextMap = {
+      objectAttributeDefinitions: 'Attribute Definitions',
+      objectAttributeGroups: 'Attribute Groups'
+    };
+
+    // Setup parent nodes for the attribute definition & the attribute
+    // Group nodes to be added to.
+    return Object.keys(displayTextMap).map(ctnrName => {
+      const metaNode = new MetadataNode(
+        displayTextMap[ctnrName],
+        TreeItemCollapsibleState.Collapsed,
+        {
+          parentContainer: ctnrName,
+          parentId:
+            element.parentId + '.' + element.objectTypeDefinition.objectType
+        }
+      );
+
+      return metaNode;
+    });
+  }
+
+  /**
+   * Gets the children elements of AttributeValueDefinition type nodes.
+   * @param {MetadataNode} element - The MetadataNode instance.
+   * @return {Promise<MetadataNode[]>}
+   */
+  private async getAttributeValueDefinitionChildren(
+    element: MetadataNode
+  ): Promise<MetadataNode[]> {
+    return Object.keys(element.objectAttributeValueDefinition).map(key => {
+      const value = element.objectAttributeValueDefinition[key];
+
+      if (
+        typeof value === 'string' ||
+        typeof value === 'number' ||
+        typeof value === 'boolean'
+      ) {
+        // == Primitive Types
+        return new MetadataNode(
+          key + ': ' + value,
+          TreeItemCollapsibleState.None,
+          {
+            parentId: element.parentId + 'objectAttributeValueDefinition'
+          }
+        );
+      } else {
+        // == Localized String
+        return new MetadataNode(
+          key + ': ' + value.default,
+          TreeItemCollapsibleState.None,
+          {
+            parentId: element.parentId + 'objectAttributeValueDefinition'
+          }
+        );
+      }
+    });
+  }
+
+  /**
+   * Gets the children elements of ObjectAttributeGroup type nodes.
+   * @param {MetadataNode} element - The MetadataNode instance.
+   * @return {Promise<MetadataNode[]>}
+   */
+  private async getAttributeGroupChildren(
+    element: MetadataNode
+  ): Promise<MetadataNode[]> {
+    const attrGroup = element.objectAttributeGroup;
+    return Object.keys(attrGroup).map(groupProperty => {
+      return new MetadataNode(groupProperty, TreeItemCollapsibleState.None, {
+        parentId: element.parentId + '.' + attrGroup.id
+      });
+    });
+  }
+
+  /**
+   * Gets the children elements of ObjectAttributeDefinition type nodes.
+   * @param {MetadataNode} element - The MetadataNode instance.
+   * @return {Promise<MetadataNode[]>}
+   */
+  private async getAttributeDefinitionChildren(
+    element: MetadataNode
+  ): Promise<MetadataNode[]> {
+    const objAttrDef: ObjectAttributeDefinition =
+      element.objectAttributeDefinition;
+
+    // Loop through the member properties and handle each possible type
+    // for display as a node on the tree.
+    return Object.keys(objAttrDef).map(key => {
+      // == Primitive Types
+      if (
+        typeof objAttrDef[key] === 'string' ||
+        typeof objAttrDef[key] === 'number' ||
+        typeof objAttrDef[key] === 'boolean'
+      ) {
+        return new MetadataNode(
+          key + ' : ' + objAttrDef[key],
+          TreeItemCollapsibleState.None,
+          {
+            parentId:
+              element.parentId + '.' + element.objectAttributeDefinition.id
+          }
+        );
+      } else if (
+        // == Localized Strings
+        typeof objAttrDef[key] === 'object' &&
+        objAttrDef[key] !== null &&
+        typeof objAttrDef[key].default === 'string'
+      ) {
+        return new MetadataNode(
+          key + ' : ' + objAttrDef[key].default,
+          TreeItemCollapsibleState.None,
+          {
+            parentId:
+              element.parentId + '.' + element.objectAttributeDefinition.id
+          }
+        );
+      } else if (objAttrDef[key] instanceof ObjectAttributeValueDefinition) {
+        // == ObjectAttributeValueDefinition
+        if (typeof objAttrDef[key].id !== 'undefined') {
+          return new MetadataNode(
+            key + ': ' + objAttrDef[key].id,
+            TreeItemCollapsibleState.Collapsed,
+            {
+              objectAttributeValueDefinition: objAttrDef[key],
+              parentId:
+                element.parentId + '.' + element.objectAttributeDefinition.id
+            }
+          );
+        }
+        return new MetadataNode(
+          key + ': (undefined)',
+          TreeItemCollapsibleState.None,
+          {
+            objectAttributeValueDefinition: objAttrDef[key],
+            parentId:
+              element.parentId + '.' + element.objectAttributeDefinition.id
+          }
+        );
+      }
+    });
   }
 }

--- a/src/documents/ObjectAttributeGroup.ts
+++ b/src/documents/ObjectAttributeGroup.ts
@@ -1,3 +1,5 @@
+import ObjectAttributeDefinition from './ObjectAttributeDefinition';
+
 /**
  * @file ObjectAttributeGroup.ts
  * @fileoverview - Exports the ObjectAttributeGroup class which is a model for the OCAPI
@@ -9,12 +11,48 @@
  * @classdesc - Used for handling the OCAPI document: ObjectAttributeGroup.
  */
 export default class ObjectAttributeGroup {
+  // Class Member Fields
+  public attributeDefinitions: ObjectAttributeDefinition[] = [];
+  public attributeDefinitionsCount: number = 0;
+  public description: string = '';
+  public displayName: string = '';
+  public id: string = '';
+  public internal: boolean = false;
+  public link: string = '';
+  public position: number = 0;
+
   /**
    * @param {Object} args - The raw JSON object document returned from a call to
    *    SFCC OCAPI.
    * @constructor
    */
   constructor(args) {
-    /** @todo */
+    if (args) {
+      if (args.attribute_definitions) {
+        this.attributeDefinitions = args.attribute_definitions.map(def =>
+            new ObjectAttributeDefinition({def}));
+      }
+      if (args.attribute_definitions_count) {
+        this.attributeDefinitionsCount = args.attribute_definitions_count;
+      }
+      if (args.description) {
+        this.description = args.description;
+      }
+      if (args.display_name) {
+        this.displayName = args.display_name;
+      }
+      if (args.id) {
+        this.id = args.id;
+      }
+      if (args.internal) {
+        this.internal = args.internal;
+      }
+      if (args.link) {
+        this.link = args.link;
+      }
+      if (args.position) {
+        this.position = args.position;
+      }
+    }
   }
 }

--- a/src/documents/ObjectAttributeGroups.ts
+++ b/src/documents/ObjectAttributeGroups.ts
@@ -1,20 +1,21 @@
 /**
- * @file ObjectTypeDefinition.ts
- * @fileoverview - Provides a class for standardized handling of the OCAPI
- * object_type_definitions document type.
+ * @file ObjectAttributeGroups.ts
+ * @fileoverview - Exports a single class for working with system object
+ *    attribute groups with OCAPI.
  */
 
-import ObjectTypeDefinition from './ObjectTypeDefinition';
+import ObjectAttributeGroup from './ObjectAttributeGroup';
 
 /**
- * @class ObjectTypeDefinitions
- * @classdesc - A data model class for working with the OCAPI data API's
- *    object_type_definitions document type.
+ * @class ObjectAttributeGroups
+ * @classdesc - Represents a list of returned attribute groups from a call to
+ *    the API endpoint to retrieve the system object attribute groups of a SFCC
+ *    system object.
  */
-export class ObjectTypeDefinitions {
-  // Declare class member variables.
+export default class ObjectAttributeGroups {
+  // Class Member Fields
   public count: number = 0;
-  public data: ObjectTypeDefinition[] = [];
+  public data: ObjectAttributeGroup[] = [];
   public expand: string[] = [];
   public next: string = '';
   public previous: string = '';
@@ -23,18 +24,16 @@ export class ObjectTypeDefinitions {
   public total: number = 0;
 
   /**
-   * @param {Object} [args] - The raw JSON document returned from an OCAPI call.
+   * @param {Object} [args] - Raw JSON response from OCAPI call.
    * @constructor
    */
   constructor(args) {
-    // Get any arguments that were passed into the instance to set the values on
-    // Object initialization.
     if (args) {
       if (args.count) {
         this.count = args.count;
       }
       if (args.data) {
-        this.data = args.data.map(type => new ObjectTypeDefinition(type));
+        this.data = args.data.map(group => new ObjectAttributeGroup(group));
       }
       if (args.expand) {
         this.expand = args.expand;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,16 +21,19 @@ export function activate(context: ExtensionContext) {
    * Binds the handler function for the event. The command has been defined in
    * the package.json file.
    *
-   * @listens extension.sfccexplorer.systemobjectattribute.add
+   * @listens extension.sfccexplorer.systemobject.addattribute
    */
   const addAttributeDisposable: Disposable = commands.registerCommand(
-    'extension.sfccexplorer.systemobjectattribute.add', (metaNode: MetadataNode) => {
+    'extension.sfccexplorer.systemobject.addattribute', (metaNode: MetadataNode) => {
       ocapiHelper.addAttributeNode(metaNode)
         .then(data => {
           console.log(data);
           metaView.currentProvider.refresh();
         }
-      ).catch(err => console.log(err));
+      ).catch(err => {
+        window.showErrorMessage('Unable to add attribute: {0}', err);
+        console.log(err);
+      });
     }
   );
 
@@ -43,6 +46,25 @@ export function activate(context: ExtensionContext) {
   const refreshTreeDisposable: Disposable = commands.registerCommand(
     'extension.sfccexplorer.refresh', (metaDataView: any) => {
       metaView.currentProvider.refresh();
+    }
+  );
+
+  /**
+   * Binds the handler for the context menu command to set the default value of
+   * a system object attribute.
+   *
+   * @listens extension.sfccexplorer.systemobjectattribute.setdefault
+   */
+  const setDefaultDisposable: Disposable = commands.registerCommand(
+    'extension.sfccexplorer.systemobjectattribute.setdefault',
+    (metaNode: MetadataNode) => {
+      ocapiHelper.setDefaultAttributeValue(metaNode)
+        .then(data => {
+
+        }).catch(err => {
+          window.showErrorMessage('Unable to set default value: {0}', err);
+          console.log(err)
+        });
     }
   );
 

--- a/src/helpers/OCAPIHelper.ts
+++ b/src/helpers/OCAPIHelper.ts
@@ -25,7 +25,7 @@ import { MetadataNode } from '../components/MetadataNode';
  * object definitions used by the SFCC instance.
  */
 export default class OCAPIHelper {
-  private metadataView : MetadataView;
+  private metadataView: MetadataView;
   public static readonly ATTRIBUTE_TYPES = [
     'Boolean',
     'Date',
@@ -49,7 +49,7 @@ export default class OCAPIHelper {
    * @param {MetadataView} metaView - The MetadataView class instance that can
    *    be used to read the seleted items in the MetadataViewProvider instance.
    */
-  constructor(metaView : MetadataView) {
+  constructor(metaView: MetadataView) {
     this.metadataView = metaView;
   }
 
@@ -114,7 +114,6 @@ export default class OCAPIHelper {
 
     return Promise.resolve(_callResult);
   }
-
 
   /**
    * Validates that a string is an allowed Id for a SFCC SystemObject attribute.
@@ -203,7 +202,7 @@ export default class OCAPIHelper {
     };
     const descriptionInputOptions = {
       prompt: 'Enter Attribute Description (Optional):'
-    }
+    };
 
     /* Begin Form Wizard
        ====================================================================== */
@@ -248,7 +247,6 @@ export default class OCAPIHelper {
 
       // If the user cancels, then exit the wizard.
       if (typeof description === 'undefined') {
-
       }
 
       // Assign attribute values to the request document object.
@@ -261,8 +259,7 @@ export default class OCAPIHelper {
       // const selected = metadataView.currentProvider.;
 
       // Return the reuslt of the API call.
-      return this.addAttributeDefiniton(systemObjectId,
-        objAttributeDefinition);
+      return this.addAttributeDefiniton(systemObjectId, objAttributeDefinition);
     } catch (e) {
       console.log(e);
       return Promise.reject({
@@ -271,5 +268,40 @@ export default class OCAPIHelper {
         errorObject: e
       });
     }
+  }
+
+  /**
+   * Makes an OCAPI call to set the default value of a system object attribute
+   * if this operation is supported on the attribute/object type combination.
+   *
+   * @param {MetadataNode} node - The node object that was selected when the
+   *    context menu option was selected.
+   * @returns {Promise<any>} - Returns a promise that resolves with the reuslts
+   *    of the call to the OCAPI endpoint.
+   */
+  public setDefaultAttributeValue(node: MetadataNode): Promise<any> {
+    const ALLOWED_SYSTEM_OBJECTS = [
+      'SitePreferences',
+      'OrganizationPreferences'
+    ];
+    const ALLOWED_ATTRIBUTE_TYPES = ['string', 'number', 'boolean'];
+
+    const attributeDefinition: ObjectAttributeDefinition =
+      node.objectAttributeDefinition;
+
+    let isCallAllowed = ALLOWED_SYSTEM_OBJECTS.some(
+      type => 'root.systemObjectDefinitions.' + type === node.parentId
+    );
+
+    // Check if this is a system object that allows for default attribute values,
+    // and that the data type allows for default values.
+    if (
+      isCallAllowed &&
+      ALLOWED_ATTRIBUTE_TYPES.indexOf(attributeDefinition.valueType) > -1
+    ) {
+      /** @todo make call to the OCAPI api to set the default value */
+    }
+
+    return Promise.reject('METHOD NOT IMPLEMENTED');
   }
 }

--- a/src/interfaces/INodeData.ts
+++ b/src/interfaces/INodeData.ts
@@ -13,11 +13,14 @@ import ObjectAttributeGroup from '../documents/ObjectAttributeGroup';
 import ObjectAttributeDefinition from '../documents/ObjectAttributeDefinition';
 import ObjectAttributeValueDefinition from '../documents/ObjectAttributeValueDefinition';
 
+/** @interface INodeData */
 export default interface INodeData {
+    parentId: string;
     objectAttributeDefinition?: ObjectAttributeDefinition;
-    obtectAttributeGroup?: ObjectAttributeGroup;
+    objectAttributeGroup?: ObjectAttributeGroup;
     objectAttributeValueDefinition?: ObjectAttributeValueDefinition;
     objectTypeDefinition?: ObjectTypeDefinition;
+    parentContainer?: string;
     baseNodeName?: string;
     nodeValue?: string|number;
 }


### PR DESCRIPTION
## Summary
Adds a branch to the tree view to view the attribute groups of the system object attribute that is expanded.

![image](https://user-images.githubusercontent.com/16811151/50060197-c5e23280-015e-11e9-99ca-8d0283d069af.png)
