### PR TITLE
Feature/delete attribute group

### DIFF
--- a/src/components/MetadataViewProvider.ts
+++ b/src/components/MetadataViewProvider.ts
@@ -249,8 +249,7 @@ export class MetadataViewProvider
       'getAll',
       {
         count: 200,
-        select: '(**)',
-        object_type: 'SystemObject'
+        select: '(**)'
       }
     );
 

--- a/src/components/MetadataViewProvider.ts
+++ b/src/components/MetadataViewProvider.ts
@@ -249,7 +249,8 @@ export class MetadataViewProvider
       'getAll',
       {
         count: 200,
-        select: '(**)'
+        select: '(**)',
+        object_type: 'SystemObject'
       }
     );
 
@@ -259,12 +260,10 @@ export class MetadataViewProvider
     if (_callResult.data && Array.isArray(_callResult.data)) {
       // Add the display name to the custom objects so that they can be
       // easily identified as custom.
-      return _callResult.data.map(sysObj => {
-        let name =
-          sysObj.object_type === 'CustomObject' &&
-          typeof sysObj.display_name !== 'undefined'
-            ? sysObj.display_name.default + ' (CustomObject)'
-            : sysObj.object_type;
+      return _callResult.data.filter(obj => {
+        return obj.object_type !== 'CustomObject';
+      }).map(sysObj => {
+        let name = sysObj.object_type;
 
         // Create a MetaDataNode instance which implements the TreeItem
         // interface and holds the data of the document type that it


### PR DESCRIPTION
Filter the Custom Object definitions from the System Object definitions view. They are not compatible with the same API calls that are made from the context menus so it doesn't make sense to have them as siblings in the tree view.